### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Coho04/EasyWallet/security/code-scanning/3](https://github.com/Coho04/EasyWallet/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/build.yml` at the workflow root (right after `on:` block and before `jobs:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal required scope is:

- `contents: read` (needed by `actions/checkout`)

No additional write scopes are required based on the shown steps.

This preserves existing functionality while enforcing least privilege and resolving the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
